### PR TITLE
Added buffer package dep and require it

### DIFF
--- a/lib/internal/streams/buffer_list.js
+++ b/lib/internal/streams/buffer_list.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { StringPrototypeSlice, SymbolIterator, TypedArrayPrototypeSet, Uint8Array } = require('../../ours/primordials')
 
 const { inspect } = require('../../ours/util')

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { PromisePrototypeThen, SymbolAsyncIterator, SymbolIterator } = require('../../ours/primordials')
 
 const { ERR_INVALID_ARG_TYPE, ERR_STREAM_NULL_VALUES } = require('../../ours/errors').codes

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const {
   ArrayPrototypeIndexOf,
   NumberIsInteger,

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -23,6 +23,8 @@
 // the drain event emission and buffering.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const {
   ArrayPrototypeSlice,
   Error,

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { ObjectDefineProperty, ObjectKeys, ReflectApply } = require('./ours/primordials')
 
 const {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "abort-controller": "^3.0.0"
+    "abort-controller": "^3.0.0",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
@@ -55,7 +56,6 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@sinonjs/fake-timers": "^9.1.2",
     "browserify": "^17.0.0",
-    "buffer-es6": "^4.9.3",
     "c8": "^7.11.2",
     "esbuild": "^0.14.39",
     "esbuild-plugin-alias": "^0.2.1",

--- a/src/test/browser/test-stream-big-packet.js
+++ b/src/test/browser/test-stream-big-packet.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const { Transform } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream-pipe-cleanup-pause.js
+++ b/src/test/browser/test-stream-pipe-cleanup-pause.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const stream = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream-pipeline.js
+++ b/src/test/browser/test-stream-pipeline.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable, Writable, pipeline } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream-readable-event.js
+++ b/src/test/browser/test-stream-readable-event.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream-transform-constructor-set-methods.js
+++ b/src/test/browser/test-stream-transform-constructor-set-methods.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Transform } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream-transform-split-objectmode.js
+++ b/src/test/browser/test-stream-transform-split-objectmode.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Transform } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream-unshift-empty-chunk.js
+++ b/src/test/browser/test-stream-unshift-empty-chunk.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream-unshift-read-race.js
+++ b/src/test/browser/test-stream-unshift-read-race.js
@@ -7,6 +7,7 @@
 // 3. push() after the EOF signaling null is an error.
 // 4. _read() is not called after pushing the EOF null chunk.
 
+const { Buffer } = require('buffer')
 const stream = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream-writable-change-default-encoding.js
+++ b/src/test/browser/test-stream-writable-change-default-encoding.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const stream = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream-writable-constructor-set-methods.js
+++ b/src/test/browser/test-stream-writable-constructor-set-methods.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream-writable-decoded-encoding.js
+++ b/src/test/browser/test-stream-writable-decoded-encoding.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const stream = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream-writev.js
+++ b/src/test/browser/test-stream-writev.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const stream = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream2-base64-single-char-read-end.js
+++ b/src/test/browser/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream2-compatibility.js
+++ b/src/test/browser/test-stream2-compatibility.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream2-large-read-stall.js
+++ b/src/test/browser/test-stream2-large-read-stall.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream2-pipe-error-handling.js
+++ b/src/test/browser/test-stream2-pipe-error-handling.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const stream = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream2-readable-empty-buffer-no-eof.js
+++ b/src/test/browser/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream2-readable-from-list.js
+++ b/src/test/browser/test-stream2-readable-from-list.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { _fromList: fromList } = require('../../lib/_stream_readable')
 const BufferList = require('../../lib/internal/streams/buffer_list')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream2-readable-legacy-drain.js
+++ b/src/test/browser/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Stream, Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream2-readable-non-empty-end.js
+++ b/src/test/browser/test-stream2-readable-non-empty-end.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/src/test/browser/test-stream2-readable-wrap.js
+++ b/src/test/browser/test-stream2-readable-wrap.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { EventEmitter: EE } = require('events')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream2-set-encoding.js
+++ b/src/test/browser/test-stream2-set-encoding.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream2-transform.js
+++ b/src/test/browser/test-stream2-transform.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { PassThrough, Transform } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream2-writable.js
+++ b/src/test/browser/test-stream2-writable.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const { Duplex, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream3-pause-then-read.js
+++ b/src/test/browser/test-stream3-pause-then-read.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Buffer } = require('buffer')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
 

--- a/test/browser/fixtures/esbuild-browsers-shims.mjs
+++ b/test/browser/fixtures/esbuild-browsers-shims.mjs
@@ -1,8 +1,6 @@
-import * as bufferModule from 'buffer-es6'
 import * as processModule from 'process-es6'
 
 export const process = processModule
-export const Buffer = bufferModule.Buffer
 
 export function setImmediate(fn, ...args) {
   setTimeout(() => fn(...args), 1)

--- a/test/browser/fixtures/rollup.browser.config.mjs
+++ b/test/browser/fixtures/rollup.browser.config.mjs
@@ -16,8 +16,7 @@ export default {
     commonjs(),
     nodePolyfill(),
     inject({
-      process: resolve('node_modules/process-es6/browser.js'),
-      Buffer: [resolve('node_modules/buffer-es6/index.js'), 'Buffer']
+      process: resolve('node_modules/process-es6/browser.js')
     }),
     nodeResolve({
       browser: true,

--- a/test/browser/fixtures/webpack.browser.config.mjs
+++ b/test/browser/fixtures/webpack.browser.config.mjs
@@ -21,8 +21,7 @@ export default {
       raw: true
     }),
     new webpack.ProvidePlugin({
-      process: require.resolve('process-es6'),
-      Buffer: [require.resolve('buffer-es6'), 'Buffer']
+      process: require.resolve('process-es6')
     })
   ],
   resolve: {

--- a/test/browser/test-stream-big-packet.js
+++ b/test/browser/test-stream-big-packet.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const inherits = require('inherits')
 
 const { Transform } = require('../../lib/ours/index')

--- a/test/browser/test-stream-pipe-cleanup-pause.js
+++ b/test/browser/test-stream-pipe-cleanup-pause.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const stream = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream-pipeline.js
+++ b/test/browser/test-stream-pipeline.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable, Writable, pipeline } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream-readable-event.js
+++ b/test/browser/test-stream-readable-event.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream-transform-constructor-set-methods.js
+++ b/test/browser/test-stream-transform-constructor-set-methods.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Transform } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream-transform-split-objectmode.js
+++ b/test/browser/test-stream-transform-split-objectmode.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Transform } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream-unshift-empty-chunk.js
+++ b/test/browser/test-stream-unshift-empty-chunk.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream-unshift-read-race.js
+++ b/test/browser/test-stream-unshift-read-race.js
@@ -5,6 +5,8 @@
 // 3. push() after the EOF signaling null is an error.
 // 4. _read() is not called after pushing the EOF null chunk.
 
+const { Buffer } = require('buffer')
+
 const stream = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream-writable-change-default-encoding.js
+++ b/test/browser/test-stream-writable-change-default-encoding.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const inherits = require('inherits')
 
 const stream = require('../../lib/ours/index')

--- a/test/browser/test-stream-writable-constructor-set-methods.js
+++ b/test/browser/test-stream-writable-constructor-set-methods.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Writable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream-writable-decoded-encoding.js
+++ b/test/browser/test-stream-writable-decoded-encoding.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const inherits = require('inherits')
 
 const stream = require('../../lib/ours/index')

--- a/test/browser/test-stream-writev.js
+++ b/test/browser/test-stream-writev.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const stream = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream2-base64-single-char-read-end.js
+++ b/test/browser/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable, Writable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream2-compatibility.js
+++ b/test/browser/test-stream2-compatibility.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const inherits = require('inherits')
 
 const { Readable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-large-read-stall.js
+++ b/test/browser/test-stream2-large-read-stall.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream2-pipe-error-handling.js
+++ b/test/browser/test-stream2-pipe-error-handling.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const stream = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/browser/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream2-readable-from-list.js
+++ b/test/browser/test-stream2-readable-from-list.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { _fromList: fromList } = require('../../lib/_stream_readable')
 
 const BufferList = require('../../lib/internal/streams/buffer_list')

--- a/test/browser/test-stream2-readable-legacy-drain.js
+++ b/test/browser/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Stream, Readable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream2-readable-non-empty-end.js
+++ b/test/browser/test-stream2-readable-non-empty-end.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/browser/test-stream2-readable-wrap.js
+++ b/test/browser/test-stream2-readable-wrap.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { EventEmitter: EE } = require('events')
 
 const { Readable, Writable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-set-encoding.js
+++ b/test/browser/test-stream2-set-encoding.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const inherits = require('inherits')
 
 const { Readable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-transform.js
+++ b/test/browser/test-stream2-transform.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { PassThrough, Transform } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream2-writable.js
+++ b/test/browser/test-stream2-writable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const inherits = require('inherits')
 
 const { Duplex, Writable } = require('../../lib/ours/index')

--- a/test/browser/test-stream3-pause-then-read.js
+++ b/test/browser/test-stream3-pause-then-read.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const { Readable, Writable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -24,6 +24,8 @@
 
 const process = global.process // Some tests tamper with the process global.
 
+const { Buffer } = require('buffer')
+
 const assert = require('assert')
 
 const { exec, execSync, spawnSync } = require('child_process')

--- a/test/parallel/test-readable-from.js
+++ b/test/parallel/test-readable-from.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-readable-large-hwm.js
+++ b/test/parallel/test-readable-large-hwm.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-await-drain-writers-in-synchronously-recursion-write.js
+++ b/test/parallel/test-stream-await-drain-writers-in-synchronously-recursion-write.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-backpressure.js
+++ b/test/parallel/test-stream-backpressure.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -1,6 +1,8 @@
 // Flags: --expose-internals
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-decoder-objectmode.js
+++ b/test/parallel/test-stream-decoder-objectmode.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-duplex-readable-end.js
+++ b/test/parallel/test-stream-duplex-readable-end.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-flatMap.js
+++ b/test/parallel/test-stream-flatMap.js
@@ -16,6 +16,8 @@ if (typeof AbortSignal.abort !== 'function') {
 
 ;('use strict')
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-pipe-await-drain-manual-resume.js
+++ b/test/parallel/test-stream-pipe-await-drain-manual-resume.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-pipe-await-drain-push-while-write.js
+++ b/test/parallel/test-stream-pipe-await-drain-push-while-write.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-pipe-await-drain.js
+++ b/test/parallel/test-stream-pipe-await-drain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-pipe-cleanup-pause.js
+++ b/test/parallel/test-stream-pipe-cleanup-pause.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-pipe-multiple-pipes.js
+++ b/test/parallel/test-stream-pipe-multiple-pipes.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-promises.js
+++ b/test/parallel/test-stream-promises.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-emittedReadable.js
+++ b/test/parallel/test-stream-readable-emittedReadable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-flow-recursion.js
+++ b/test/parallel/test-stream-readable-flow-recursion.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-infinite-read.js
+++ b/test/parallel/test-stream-readable-infinite-read.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-resumeScheduled.js
+++ b/test/parallel/test-stream-readable-resumeScheduled.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
+++ b/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-unshift.js
+++ b/test/parallel/test-stream-readable-unshift.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readableListening-state.js
+++ b/test/parallel/test-stream-readableListening-state.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-toArray.js
+++ b/test/parallel/test-stream-toArray.js
@@ -16,6 +16,8 @@ if (typeof AbortSignal.abort !== 'function') {
 
 ;('use strict')
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-transform-flush-data.js
+++ b/test/parallel/test-stream-transform-flush-data.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-transform-split-objectmode.js
+++ b/test/parallel/test-stream-transform-split-objectmode.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-write-final.js
+++ b/test/parallel/test-stream-write-final.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-decode-partial.js
+++ b/test/parallel/test-stream2-decode-partial.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-finish-pipe-error.js
+++ b/test/parallel/test-stream2-finish-pipe-error.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-pipe-error-handling.js
+++ b/test/parallel/test-stream2-pipe-error-handling.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -21,6 +21,8 @@
 // Flags: --expose-internals
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream3-cork-end.js
+++ b/test/parallel/test-stream3-cork-end.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream3-cork-uncork.js
+++ b/test/parallel/test-stream3-cork-uncork.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const { Buffer } = require('buffer')
+
 const tap = require('tap')
 
 const silentConsole = {


### PR DESCRIPTION
The `Buffer` class is available within the global scope in Node.js.This class is unavailable in browser environments, but the [buffer](https://www.npmjs.com/package/buffer) package can be used as a polyfill. Node.js provides an internal `buffer` module with the same interface. If the `Buffer` class is required from `buffer`, in Node.js, the internal module is still used, and in browser environments, the polyfill is used.

This PR
- adds the `buffer` dependency
- requires the `buffer` package in every file (lib+test) where `Buffer` is used
- removes the workarounds to load polyfills in the browser tests
- uses `buffer` instead of `buffer-es6` in the browser tests