### PR TITLE
Added process dep and require it

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const {
   aggregateTwoErrors,
   codes: { ERR_MULTIPLE_CALLBACK },

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const bufferModule = require('buffer')
 
 const {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -2,6 +2,8 @@
 // permission from the author, Mathias Buus (@mafintosh).
 'use strict'
 
+const process = require('process')
+
 const { AbortError, codes } = require('../../ours/errors')
 
 const { ERR_INVALID_ARG_TYPE, ERR_STREAM_PREMATURE_CLOSE } = codes

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const { PromisePrototypeThen, SymbolAsyncIterator, SymbolIterator } = require('../../ours/primordials')

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -2,6 +2,8 @@
 // permission from the author, Mathias Buus (@mafintosh).
 'use strict'
 
+const process = require('process')
+
 const { ArrayIsArray, Promise, SymbolAsyncIterator } = require('../../ours/primordials')
 
 const eos = require('./end-of-stream')

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const {

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -23,6 +23,8 @@
 // the drain event emission and buffering.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "process": "^0.11.10"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
@@ -66,7 +67,6 @@
     "eslint-plugin-promise": "^6.0.0",
     "playwright": "^1.21.1",
     "prettier": "^2.6.2",
-    "process-es6": "^0.11.6",
     "rollup": "^2.72.1",
     "rollup-plugin-polyfill-node": "^0.9.0",
     "tap": "^16.2.0",

--- a/process
+++ b/process
@@ -1,0 +1,3 @@
+// workaround for browserify bug: https://github.com/browserify/browserify/issues/1986
+
+module.exports = require('./node_modules/process')

--- a/src/test/browser/fixtures/esbuild-browsers-shims.mjs
+++ b/src/test/browser/fixtures/esbuild-browsers-shims.mjs
@@ -1,8 +1,6 @@
-import * as bufferModule from 'buffer-es6'
-import * as processModule from 'process-es6'
+import * as processModule from 'process'
 
 export const process = processModule
-export const Buffer = bufferModule.Buffer
 
 export function setImmediate(fn, ...args) {
   setTimeout(() => fn(...args), 1)

--- a/src/test/browser/fixtures/rollup.browser.config.mjs
+++ b/src/test/browser/fixtures/rollup.browser.config.mjs
@@ -1,13 +1,10 @@
 import commonjs from '@rollup/plugin-commonjs'
-import inject from '@rollup/plugin-inject'
 import nodeResolve from '@rollup/plugin-node-resolve'
-import { resolve } from 'path'
 import nodePolyfill from 'rollup-plugin-polyfill-node'
 
 export default {
   input: ['test/browser/test-browser.js'],
   output: {
-    intro: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 1) }',
     file: 'tmp/rollup/suite.browser.js',
     format: 'iife',
     name: 'readableStreamTestSuite'
@@ -15,10 +12,6 @@ export default {
   plugins: [
     commonjs(),
     nodePolyfill(),
-    inject({
-      process: resolve('node_modules/process-es6/browser.js'),
-      Buffer: [resolve('node_modules/buffer-es6/index.js'), 'Buffer']
-    }),
     nodeResolve({
       browser: true,
       preferBuiltins: false

--- a/src/test/browser/fixtures/webpack.browser.config.mjs
+++ b/src/test/browser/fixtures/webpack.browser.config.mjs
@@ -21,8 +21,7 @@ export default {
       raw: true
     }),
     new webpack.ProvidePlugin({
-      process: require.resolve('process-es6'),
-      Buffer: [require.resolve('buffer-es6'), 'Buffer']
+      process: require.resolve('process')
     })
   ],
   resolve: {

--- a/src/test/browser/test-stream-big-packet.js
+++ b/src/test/browser/test-stream-big-packet.js
@@ -56,7 +56,7 @@ module.exports = function (t) {
 
   // Write some small data in next IO loop, which will never be written to s3
   // Because 'drain' event is not emitted from s1 and s1 is still paused
-  setImmediate(s1.write.bind(s1), 'later')
+  setTimeout(s1.write.bind(s1, 'later'), 1)
 
   function indexOf(xs, x) {
     for (let i = 0, l = xs.length; i < l; i++) {

--- a/src/test/browser/test-stream-pipe-cleanup-pause.js
+++ b/src/test/browser/test-stream-pipe-cleanup-pause.js
@@ -28,13 +28,13 @@ module.exports = function (t) {
     reader.pipe(writer2)
     reader.push(buffer)
 
-    setImmediate(function () {
+    setTimeout(function () {
       reader.push(buffer)
 
-      setImmediate(function () {
+      setTimeout(function () {
         reader.push(buffer)
-      })
-    })
+      }, 1)
+    }, 1)
   })
 
   writer2._write = function (chunk, encoding, cb) {

--- a/src/test/browser/test-stream-pipe-cleanup.js
+++ b/src/test/browser/test-stream-pipe-cleanup.js
@@ -2,6 +2,7 @@
 // This test asserts that Stream.prototype.pipe does not leave listeners
 // hanging on the source or dest.
 
+const process = require('process')
 const inherits = require('inherits')
 const { Stream } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream-pipeline.js
+++ b/src/test/browser/test-stream-pipeline.js
@@ -75,9 +75,9 @@ module.exports = function (test) {
 
     _read2.push('data')
 
-    setImmediate(function () {
+    setTimeout(function () {
       return _read2.destroy()
-    })
+    }, 1)
 
     pipeline(_read2, _write, (err) => {
       t.equal(err.message, 'Premature close')
@@ -99,9 +99,9 @@ module.exports = function (test) {
 
     _read3.push('data')
 
-    setImmediate(function () {
+    setTimeout(function () {
       return _read3.destroy(new Error('kaboom'))
-    })
+    }, 1)
 
     const dst = pipeline(_read3, _write2, (err) => {
       t.equal(err.message, 'kaboom')

--- a/src/test/browser/test-stream-push-strings.js
+++ b/src/test/browser/test-stream-push-strings.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const inherits = require('inherits')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream-transform-split-objectmode.js
+++ b/src/test/browser/test-stream-transform-split-objectmode.js
@@ -52,9 +52,9 @@ module.exports = function (t) {
   serializer.on('end', function () {
     t.equals(serialized[0], 42, 'searlizer ended')
   })
-  setImmediate(function () {
+  setTimeout(function () {
     serializer.end()
-  })
+  }, 1)
 }
 
 module.exports[kReadableStreamSuiteName] = 'stream-transform-split-objectmode'

--- a/src/test/browser/test-stream-writable-constructor-set-methods.js
+++ b/src/test/browser/test-stream-writable-constructor-set-methods.js
@@ -29,13 +29,13 @@ module.exports = function (t) {
   w2.write(Buffer.from('blerg'))
   w2.end()
 
-  setImmediate(function () {
+  setTimeout(function () {
     t.equal(w._write, _write)
     t.ok(_writeCalled)
     t.equal(w2._writev, _writev)
     t.equal(dLength, 2)
     t.ok(_writevCalled)
-  })
+  }, 1)
 }
 
 module.exports[kReadableStreamSuiteName] = 'stream-writable-constructor-set-methods'

--- a/src/test/browser/test-stream2-base64-single-char-read-end.js
+++ b/src/test/browser/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Buffer } = require('buffer')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream2-objects.js
+++ b/src/test/browser/test-stream2-objects.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')
 

--- a/src/test/browser/test-stream2-push.js
+++ b/src/test/browser/test-stream2-push.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { EventEmitter: EE } = require('events')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream2-readable-empty-buffer-no-eof.js
+++ b/src/test/browser/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Buffer } = require('buffer')
 const { Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream2-readable-legacy-drain.js
+++ b/src/test/browser/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Buffer } = require('buffer')
 const { Stream, Readable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')

--- a/src/test/browser/test-stream2-transform.js
+++ b/src/test/browser/test-stream2-transform.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Buffer } = require('buffer')
 const { PassThrough, Transform } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/src/test/browser/test-stream2-unpipe-drain.js
+++ b/src/test/browser/test-stream2-unpipe-drain.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const crypto = require('crypto')
 const inherits = require('inherits')
 const stream = require('../../lib/ours/index')

--- a/src/test/browser/test-stream2-writable.js
+++ b/src/test/browser/test-stream2-writable.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Buffer } = require('buffer')
 const inherits = require('inherits')
 const { Duplex, Writable } = require('../../lib/ours/index')

--- a/src/test/browser/test-stream3-pause-then-read.js
+++ b/src/test/browser/test-stream3-pause-then-read.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const process = require('process')
 const { Buffer } = require('buffer')
 const { Readable, Writable } = require('../../lib/ours/index')
 const { kReadableStreamSuiteName } = require('./symbols')
@@ -16,7 +17,7 @@ module.exports = function (t) {
   let chunks = totalChunks
   r._read = function (n) {
     if (!(chunks % 2)) {
-      setImmediate(push)
+      setTimeout(push, 1)
     } else if (!(chunks % 3)) {
       process.nextTick(push)
     } else {
@@ -76,7 +77,7 @@ module.exports = function (t) {
         }
 
         // Nothing should be lost in between
-        setImmediate(pipeLittle)
+        setTimeout(pipeLittle, 1)
       }
     })
   }
@@ -89,7 +90,7 @@ module.exports = function (t) {
     let written = 0
     w.on('finish', function () {
       t.equal(written, 200)
-      setImmediate(read1234)
+      setTimeout(read1234, 1)
     })
     w._write = function (chunk, encoding, cb) {
       written += chunk.length
@@ -103,7 +104,7 @@ module.exports = function (t) {
           r.unshift(chunk.slice(chunk.length - diff))
         }
       } else {
-        setImmediate(cb)
+        setTimeout(cb, 1)
       }
     }
     r.pipe(w)
@@ -127,7 +128,7 @@ module.exports = function (t) {
     r.pause()
     r.resume()
     r.pause()
-    setImmediate(pipe)
+    setTimeout(pipe, 1)
   }
 
   function pipe() {

--- a/src/test/ours/test-fake-timers.js
+++ b/src/test/ours/test-fake-timers.js
@@ -14,7 +14,7 @@ function MyTransform() {
 
 util.inherits(MyTransform, Transform)
 
-const clock = fakeTimers.install({ toFake: ['setImmediate', 'nextTick'] })
+const clock = fakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })
 let stream2DataCalled = false
 
 const stream = new MyTransform()
@@ -25,9 +25,9 @@ stream.on('data', function () {
       stream2.on('end', function () {
         stream2DataCalled = true
       })
-      setImmediate(function () {
+      setTimeout(function () {
         stream2.end()
-      })
+      }, 1)
     })
     stream2.emit('data')
   })

--- a/test/browser/fixtures/esbuild-browsers-shims.mjs
+++ b/test/browser/fixtures/esbuild-browsers-shims.mjs
@@ -1,4 +1,4 @@
-import * as processModule from 'process-es6'
+import * as processModule from 'process'
 
 export const process = processModule
 

--- a/test/browser/fixtures/rollup.browser.config.mjs
+++ b/test/browser/fixtures/rollup.browser.config.mjs
@@ -1,13 +1,10 @@
 import commonjs from '@rollup/plugin-commonjs'
-import inject from '@rollup/plugin-inject'
 import nodeResolve from '@rollup/plugin-node-resolve'
-import { resolve } from 'path'
 import nodePolyfill from 'rollup-plugin-polyfill-node'
 
 export default {
   input: ['test/browser/test-browser.js'],
   output: {
-    intro: 'function setImmediate(fn, ...args) { setTimeout(() => fn(...args), 1) }',
     file: 'tmp/rollup/suite.browser.js',
     format: 'iife',
     name: 'readableStreamTestSuite'
@@ -15,9 +12,6 @@ export default {
   plugins: [
     commonjs(),
     nodePolyfill(),
-    inject({
-      process: resolve('node_modules/process-es6/browser.js')
-    }),
     nodeResolve({
       browser: true,
       preferBuiltins: false

--- a/test/browser/fixtures/webpack.browser.config.mjs
+++ b/test/browser/fixtures/webpack.browser.config.mjs
@@ -21,7 +21,7 @@ export default {
       raw: true
     }),
     new webpack.ProvidePlugin({
-      process: require.resolve('process-es6')
+      process: require.resolve('process')
     })
   ],
   resolve: {

--- a/test/browser/test-stream-big-packet.js
+++ b/test/browser/test-stream-big-packet.js
@@ -59,7 +59,7 @@ module.exports = function (t) {
   t.ok(s2.write('tiny')) // Write some small data in next IO loop, which will never be written to s3
   // Because 'drain' event is not emitted from s1 and s1 is still paused
 
-  setImmediate(s1.write.bind(s1), 'later')
+  setTimeout(s1.write.bind(s1, 'later'), 1)
 
   function indexOf(xs, x) {
     for (let i = 0, l = xs.length; i < l; i++) {

--- a/test/browser/test-stream-pipe-cleanup-pause.js
+++ b/test/browser/test-stream-pipe-cleanup-pause.js
@@ -27,12 +27,12 @@ module.exports = function (t) {
     reader.unpipe(writer1)
     reader.pipe(writer2)
     reader.push(buffer)
-    setImmediate(function () {
+    setTimeout(function () {
       reader.push(buffer)
-      setImmediate(function () {
+      setTimeout(function () {
         reader.push(buffer)
-      })
-    })
+      }, 1)
+    }, 1)
   })
 
   writer2._write = function (chunk, encoding, cb) {

--- a/test/browser/test-stream-pipe-cleanup.js
+++ b/test/browser/test-stream-pipe-cleanup.js
@@ -1,6 +1,8 @@
 'use strict' // This test asserts that Stream.prototype.pipe does not leave listeners
 // hanging on the source or dest.
 
+const process = require('process')
+
 const inherits = require('inherits')
 
 const { Stream } = require('../../lib/ours/index')

--- a/test/browser/test-stream-pipeline.js
+++ b/test/browser/test-stream-pipeline.js
@@ -68,9 +68,9 @@ module.exports = function (test) {
 
     _read2.push('data')
 
-    setImmediate(function () {
+    setTimeout(function () {
       return _read2.destroy()
-    })
+    }, 1)
     pipeline(_read2, _write, (err) => {
       t.equal(err.message, 'Premature close')
     })
@@ -90,9 +90,9 @@ module.exports = function (test) {
 
     _read3.push('data')
 
-    setImmediate(function () {
+    setTimeout(function () {
       return _read3.destroy(new Error('kaboom'))
-    })
+    }, 1)
     const dst = pipeline(_read3, _write2, (err) => {
       t.equal(err.message, 'kaboom')
     })

--- a/test/browser/test-stream-push-strings.js
+++ b/test/browser/test-stream-push-strings.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const inherits = require('inherits')
 
 const { Readable } = require('../../lib/ours/index')

--- a/test/browser/test-stream-transform-split-objectmode.js
+++ b/test/browser/test-stream-transform-split-objectmode.js
@@ -52,9 +52,9 @@ module.exports = function (t) {
   serializer.on('end', function () {
     t.equals(serialized[0], 42, 'searlizer ended')
   })
-  setImmediate(function () {
+  setTimeout(function () {
     serializer.end()
-  })
+  }, 1)
 }
 
 module.exports[kReadableStreamSuiteName] = 'stream-transform-split-objectmode'

--- a/test/browser/test-stream-writable-constructor-set-methods.js
+++ b/test/browser/test-stream-writable-constructor-set-methods.js
@@ -33,13 +33,13 @@ module.exports = function (t) {
   w2.write(Buffer.from('blerg'))
   w2.write(Buffer.from('blerg'))
   w2.end()
-  setImmediate(function () {
+  setTimeout(function () {
     t.equal(w._write, _write)
     t.ok(_writeCalled)
     t.equal(w2._writev, _writev)
     t.equal(dLength, 2)
     t.ok(_writevCalled)
-  })
+  }, 1)
 }
 
 module.exports[kReadableStreamSuiteName] = 'stream-writable-constructor-set-methods'

--- a/test/browser/test-stream2-base64-single-char-read-end.js
+++ b/test/browser/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const { Readable, Writable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-objects.js
+++ b/test/browser/test-stream2-objects.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Readable, Writable } = require('../../lib/ours/index')
 
 const { kReadableStreamSuiteName, kReadableStreamSuiteHasMultipleTests } = require('./symbols')

--- a/test/browser/test-stream2-push.js
+++ b/test/browser/test-stream2-push.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { EventEmitter: EE } = require('events')
 
 const { Readable, Writable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/browser/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const { Readable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-readable-legacy-drain.js
+++ b/test/browser/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const { Stream, Readable } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-transform.js
+++ b/test/browser/test-stream2-transform.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const { PassThrough, Transform } = require('../../lib/ours/index')

--- a/test/browser/test-stream2-unpipe-drain.js
+++ b/test/browser/test-stream2-unpipe-drain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const crypto = require('crypto')
 
 const inherits = require('inherits')

--- a/test/browser/test-stream2-writable.js
+++ b/test/browser/test-stream2-writable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const inherits = require('inherits')

--- a/test/browser/test-stream3-pause-then-read.js
+++ b/test/browser/test-stream3-pause-then-read.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const { Readable, Writable } = require('../../lib/ours/index')
@@ -19,7 +21,7 @@ module.exports = function (t) {
 
   r._read = function (n) {
     if (!(chunks % 2)) {
-      setImmediate(push)
+      setTimeout(push, 1)
     } else if (!(chunks % 3)) {
       process.nextTick(push)
     } else {
@@ -81,7 +83,7 @@ module.exports = function (t) {
           r.unshift(c.slice(c.length - diff)) // console.error('seen too much', seen, diff)
         } // Nothing should be lost in between
 
-        setImmediate(pipeLittle)
+        setTimeout(pipeLittle, 1)
       }
     })
   } // Just pipe 200 bytes, then unshift the extra and unpipe
@@ -93,7 +95,7 @@ module.exports = function (t) {
     let written = 0
     w.on('finish', function () {
       t.equal(written, 200)
-      setImmediate(read1234)
+      setTimeout(read1234, 1)
     })
 
     w._write = function (chunk, encoding, cb) {
@@ -110,7 +112,7 @@ module.exports = function (t) {
           r.unshift(chunk.slice(chunk.length - diff))
         }
       } else {
-        setImmediate(cb)
+        setTimeout(cb, 1)
       }
     }
 
@@ -134,7 +136,7 @@ module.exports = function (t) {
     r.pause()
     r.resume()
     r.pause()
-    setImmediate(pipe)
+    setTimeout(pipe, 1)
   }
 
   function pipe() {

--- a/test/ours/test-fake-timers.js
+++ b/test/ours/test-fake-timers.js
@@ -18,7 +18,7 @@ function MyTransform() {
 
 util.inherits(MyTransform, Transform)
 const clock = fakeTimers.install({
-  toFake: ['setImmediate', 'nextTick']
+  toFake: ['setTimeout', 'nextTick']
 })
 let stream2DataCalled = false
 const stream = new MyTransform()
@@ -29,9 +29,9 @@ stream.on('data', function () {
       stream2.on('end', function () {
         stream2DataCalled = true
       })
-      setImmediate(function () {
+      setTimeout(function () {
         stream2.end()
-      })
+      }, 1)
     })
     stream2.emit('data')
   })

--- a/test/parallel/test-stream-backpressure.js
+++ b/test/parallel/test-stream-backpressure.js
@@ -39,7 +39,7 @@ const rs = new stream.Readable({
 })
 const ws = stream.Writable({
   write: common.mustCall(function (data, enc, cb) {
-    setImmediate(cb)
+    setTimeout(cb, 1)
   }, 41 * 10)
 })
 rs.pipe(ws)

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')
@@ -68,7 +70,7 @@ assert(!s1.write(big)) // 'tiny' is small enough to pass through internal buffer
 assert(s2.write('tiny')) // Write some small data in next IO loop, which will never be written to s3
 // Because 'drain' event is not emitted from s1 and s1 is still paused
 
-setImmediate(s1.write.bind(s1), 'later') // Assert after two IO loops when all operations have been done.
+setTimeout(s1.write.bind(s1, 'later'), 1) // Assert after two IO loops when all operations have been done.
 
 process.on('exit', function () {
   assert(passed, 'Large buffer is not handled properly by Writable Stream')

--- a/test/parallel/test-stream-catch-rejections.js
+++ b/test/parallel/test-stream-catch-rejections.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-construct.js
+++ b/test/parallel/test-stream-construct.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -294,12 +296,12 @@ testDestroy(
   const d = new Duplex({
     readable: false,
     construct: common.mustCall((callback) => {
-      setImmediate(
+      setTimeout(
         common.mustCall(() => {
           constructed = true
           callback()
         })
-      )
+      , 1)
     }),
 
     write(chunk, encoding, callback) {

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -16,6 +16,8 @@ if (typeof AbortSignal.abort !== 'function') {
 
 ;('use strict')
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-filter.js
+++ b/test/parallel/test-stream-filter.js
@@ -33,7 +33,7 @@ const { once } = require('events')
 
 const st = require('timers').setTimeout
 
-function setTimeout(ms) {
+function setTimeoutLocal(ms) {
   return new Promise((resolve) => {
     st(resolve, ms)
   })
@@ -173,16 +173,16 @@ function setTimeout(ms) {
       }
     )
     .then(common.mustCall())
-  setImmediate(() => {
+  setTimeout(() => {
     ac.abort()
     assert.strictEqual(calls, 2)
-  })
+  }, 1)
 }
 {
   // Concurrency result order
   const stream = Readable.from([1, 2]).filter(
     async (item, { signal }) => {
-      await setTimeout(10 - item, {
+      await setTimeoutLocal(10 - item, {
         signal
       })
       return true

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -16,6 +16,8 @@ if (typeof AbortSignal.abort !== 'function') {
 
 ;('use strict')
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -155,7 +157,7 @@ const http = require('http')
   const rs = Readable.from(
     (function* () {
       yield 5
-      setImmediate(() => ac.abort())
+      setTimeout(() => ac.abort(), 1)
     })()
   )
   rs.resume()
@@ -175,7 +177,7 @@ const http = require('http')
     const ac = new AbortController()
     const { signal } = ac
     const rs = Readable.from((function* () {})())
-    setImmediate(() => ac.abort())
+    setTimeout(() => ac.abort(), 1)
     await finishedPromise(rs, {
       signal
     })
@@ -317,7 +319,7 @@ const http = require('http')
 {
   const w = new Writable({
     write(chunk, encoding, callback) {
-      setImmediate(callback)
+      setTimeout(callback, 1)
     }
   })
   finished(
@@ -350,10 +352,10 @@ function testClosed(factory) {
     let destroyed = false
     const s = factory({
       destroy(err, cb) {
-        setImmediate(() => {
+        setTimeout(() => {
           destroyed = true
           cb()
-        })
+        }, 1)
       }
     })
     s.destroy()
@@ -380,12 +382,12 @@ function testClosed(factory) {
     // Invoke with deep async.
     const s = factory({
       destroy(err, cb) {
-        setImmediate(() => {
+        setTimeout(() => {
           cb()
-          setImmediate(() => {
+          setTimeout(() => {
             finished(s, common.mustCall())
-          })
-        })
+          }, 1)
+        }, 1)
       }
     })
     s.destroy()
@@ -580,12 +582,12 @@ testClosed(
   instance.end()
   ;(async () => {
     await EE.once(instance, 'finish')
-    setImmediate(() => {
+    setTimeout(() => {
       response.write('chunk 1')
       response.write('chunk 2')
       response.write('chunk 3')
       response.end()
-    })
+    }, 1)
     let res = ''
 
     for await (const data of instance) {

--- a/test/parallel/test-stream-forEach.js
+++ b/test/parallel/test-stream-forEach.js
@@ -159,10 +159,10 @@ const { once } = require('events')
       }
     )
     .then(common.mustCall())
-  setImmediate(() => {
+  setTimeout(() => {
     ac.abort()
     assert.strictEqual(calls, 2)
-  })
+  }, 1)
 }
 {
   // Error cases

--- a/test/parallel/test-stream-pipe-await-drain-manual-resume.js
+++ b/test/parallel/test-stream-pipe-await-drain-manual-resume.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream-pipe-await-drain-push-while-write.js
+++ b/test/parallel/test-stream-pipe-await-drain-push-while-write.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream-pipe-await-drain.js
+++ b/test/parallel/test-stream-pipe-await-drain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')
@@ -36,11 +38,11 @@ writer1.once('chunk-received', () => {
     0,
     'awaitDrain initial value should be 0, actual is ' + reader._readableState.awaitDrainWriters.size
   )
-  setImmediate(() => {
+  setTimeout(() => {
     // This one should *not* get through to writer1 because writer2 is not
     // "done" processing.
     reader.push(buffer)
-  })
+  }, 1)
 }) // A "slow" consumer:
 
 writer2._write = common.mustCall((chunk, encoding, cb) => {

--- a/test/parallel/test-stream-pipe-cleanup-pause.js
+++ b/test/parallel/test-stream-pipe-cleanup-pause.js
@@ -31,12 +31,12 @@ writer1.once('chunk-received', function () {
   reader.unpipe(writer1)
   reader.pipe(writer2)
   reader.push(buffer)
-  setImmediate(function () {
+  setTimeout(function () {
     reader.push(buffer)
-    setImmediate(function () {
+    setTimeout(function () {
       reader.push(buffer)
-    })
-  })
+    }, 1)
+  }, 1)
 })
 writer2._write = common.mustCall(function (chunk, encoding, cb) {
   cb()

--- a/test/parallel/test-stream-pipe-flow-after-unpipe.js
+++ b/test/parallel/test-stream-pipe-flow-after-unpipe.js
@@ -21,7 +21,7 @@ const ws = new Writable({
   highWaterMark: 1,
   write: common.mustCall(() => {
     // Ignore the callback, this write() simply never finishes.
-    setImmediate(() => rs.unpipe(ws))
+    setTimeout(() => rs.unpipe(ws), 1)
   })
 })
 let chunks = 0

--- a/test/parallel/test-stream-pipe-flow.js
+++ b/test/parallel/test-stream-pipe-flow.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -26,7 +28,7 @@ const { Readable, Writable, PassThrough } = require('../../lib/ours/index')
   const ws = new Writable({
     highWaterMark: 0,
     objectMode: true,
-    write: (data, end, cb) => setImmediate(cb)
+    write: (data, end, cb) => setTimeout(cb, 1)
   })
   rs.on('end', common.mustCall())
   ws.on('finish', common.mustCall())

--- a/test/parallel/test-stream-pipe-manual-resume.js
+++ b/test/parallel/test-stream-pipe-manual-resume.js
@@ -29,10 +29,10 @@ function test(throwCodeInbetween) {
   const ws = stream.Writable({
     objectMode: true,
     write: common.mustCall((data, enc, cb) => {
-      setImmediate(cb)
+      setTimeout(cb, 1)
     }, n)
   })
-  setImmediate(() => throwCodeInbetween(rs, ws))
+  setTimeout(() => throwCodeInbetween(rs, ws), 1)
   rs.pipe(ws)
 }
 

--- a/test/parallel/test-stream-pipe-multiple-pipes.js
+++ b/test/parallel/test-stream-pipe-multiple-pipes.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream-pipe-needDrain.js
+++ b/test/parallel/test-stream-pipe-needDrain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-pipeline-async-iterator.js
+++ b/test/parallel/test-stream-pipeline-async-iterator.js
@@ -21,9 +21,9 @@ async function run() {
   })
   source.push('hello')
   source.push('world')
-  setImmediate(() => {
+  setTimeout(() => {
     source.destroy(_err)
-  })
+  }, 1)
   const iterator = pipeline(source, new PassThrough(), () => {})
   iterator.setEncoding('utf8')
 

--- a/test/parallel/test-stream-pipeline-queued-end-in-destroy.js
+++ b/test/parallel/test-stream-pipeline-queued-end-in-destroy.js
@@ -44,9 +44,9 @@ pipeline(
 // That should trigger the pipeline destruction.
 
 readable.push('foo')
-setImmediate(() => {
+setTimeout(() => {
   readable.destroy()
-})
+}, 1)
 /* replacement start */
 
 process.on('beforeExit', (code) => {

--- a/test/parallel/test-stream-promises.js
+++ b/test/parallel/test-stream-promises.js
@@ -68,7 +68,7 @@ assert.strictEqual(finished, promisify(stream.finished)) // pipeline success
     }
   })
   read.push('data')
-  setImmediate(() => read.destroy())
+  setTimeout(() => read.destroy(), 1)
   pipeline(read, write).catch(
     common.mustCall((err) => {
       assert.ok(err, 'should have an error')

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-data.js
+++ b/test/parallel/test-stream-readable-data.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -16,6 +16,8 @@ if (typeof AbortSignal.abort !== 'function') {
 
 ;('use strict')
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-didRead.js
+++ b/test/parallel/test-stream-readable-didRead.js
@@ -47,13 +47,13 @@ function check(readable, data, fn) {
 
   readable.on('close', common.mustCall())
   fn()
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(readable.readableDidRead, data > 0)
 
     if (data > 0) {
       assert.strictEqual(isDisturbed(readable), true)
     }
-  })
+  }, 1)
 }
 
 {

--- a/test/parallel/test-stream-readable-emit-readable-short-stream.js
+++ b/test/parallel/test-stream-readable-emit-readable-short-stream.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-emittedReadable.js
+++ b/test/parallel/test-stream-readable-emittedReadable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')
@@ -46,7 +48,7 @@ process.nextTick(
   })
 ) // These triggers two readable events
 
-setImmediate(
+setTimeout(
   common.mustCall(() => {
     readable.push('quo')
     process.nextTick(
@@ -55,7 +57,7 @@ setImmediate(
       })
     )
   })
-)
+, 1)
 const noRead = new Readable({
   read: () => {}
 })

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream-readable-hwm-0-async.js
+++ b/test/parallel/test-stream-readable-hwm-0-async.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-hwm-0-no-flow-data.js
+++ b/test/parallel/test-stream-readable-hwm-0-no-flow-data.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -57,10 +59,10 @@ assert.strictEqual(r.readableFlowing, false) // The stream emits the events asyn
 // happen on the next tick (especially since the _read implementation above
 // uses process.nextTick).
 //
-// We use setImmediate here to give the stream enough time to emit all the
+// We use setTimeout here to give the stream enough time to emit all the
 // events it's about to emit.
 
-setImmediate(() => {
+setTimeout(() => {
   // Only the _read, push, readable calls have happened. No data must be
   // emitted yet.
   assert.deepStrictEqual(calls, ['_read:a', 'push:a', 'readable']) // Calling 'r.read()' should trigger the data event.
@@ -73,11 +75,11 @@ setImmediate(() => {
   // null value as the stream doesn't know yet that it is about to reach the
   // end.
   //
-  // Using setImmediate again to give the stream enough time to emit all the
+  // Using setTimeout again to give the stream enough time to emit all the
   // events it wants to emit.
 
   assert.strictEqual(r.read(), null)
-  setImmediate(() => {
+  setTimeout(() => {
     // There's a new 'readable' event after the data has been pushed.
     // The 'end' event will be emitted only after a 'read()'.
     //
@@ -103,8 +105,8 @@ setImmediate(() => {
         'end'
       ])
     })
-  })
-})
+  }, 1)
+}, 1)
 /* replacement start */
 
 process.on('beforeExit', (code) => {

--- a/test/parallel/test-stream-readable-hwm-0.js
+++ b/test/parallel/test-stream-readable-hwm-0.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-needReadable.js
+++ b/test/parallel/test-stream-readable-needReadable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -61,12 +63,12 @@ process.nextTick(
     asyncReadable.push('bar')
   })
 )
-setImmediate(
+setTimeout(
   common.mustCall(() => {
     asyncReadable.push(null)
     assert.strictEqual(asyncReadable._readableState.needReadable, false)
   })
-)
+, 1)
 const flowing = new Readable({
   read: () => {}
 }) // Notice this must be above the on('data') call.

--- a/test/parallel/test-stream-readable-no-unneeded-readable.js
+++ b/test/parallel/test-stream-readable-no-unneeded-readable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-object-multi-push-async.js
+++ b/test/parallel/test-stream-readable-object-multi-push-async.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -189,10 +191,10 @@ const BATCH = 10
     silentConsole.log('data emitted', data)
   })
   readable.on('end', common.mustCall())
-  setImmediate(() => {
+  setTimeout(() => {
     readable.push('aaa')
     readable.push(null)
-  })
+  }, 1)
 }
 /* replacement start */
 

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')
@@ -35,11 +37,11 @@ function readAndPause() {
     rs.pause()
     expectedData--
     if (expectedData <= 0) return
-    setImmediate(function () {
+    setTimeout(function () {
       rs.removeListener('data', ondata)
       readAndPause()
       rs.resume()
-    })
+    }, 1)
   }, 1) // Only call ondata once
 
   rs.on('data', ondata)

--- a/test/parallel/test-stream-readable-readable.js
+++ b/test/parallel/test-stream-readable-readable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-reading-readingMore.js
+++ b/test/parallel/test-stream-readable-reading-readingMore.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-readable-resumeScheduled.js
+++ b/test/parallel/test-stream-readable-resumeScheduled.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
+++ b/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-transform-final-sync.js
+++ b/test/parallel/test-stream-transform-final-sync.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-transform-final.js
+++ b/test/parallel/test-stream-transform-final.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-unpipe-event.js
+++ b/test/parallel/test-stream-unpipe-event.js
@@ -35,9 +35,9 @@ class NeverEndReadable extends Readable {
   dest.on('pipe', common.mustCall())
   dest.on('unpipe', common.mustCall())
   src.pipe(dest)
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(src._readableState.pipes.length, 0)
-  })
+  }, 1)
 }
 {
   const dest = new NullWriteable()
@@ -45,9 +45,9 @@ class NeverEndReadable extends Readable {
   dest.on('pipe', common.mustCall())
   dest.on('unpipe', common.mustNotCall('unpipe should not have been emitted'))
   src.pipe(dest)
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(src._readableState.pipes.length, 1)
-  })
+  }, 1)
 }
 {
   const dest = new NullWriteable()
@@ -56,9 +56,9 @@ class NeverEndReadable extends Readable {
   dest.on('unpipe', common.mustCall())
   src.pipe(dest)
   src.unpipe(dest)
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(src._readableState.pipes.length, 0)
-  })
+  }, 1)
 }
 {
   const dest = new NullWriteable()
@@ -68,9 +68,9 @@ class NeverEndReadable extends Readable {
   src.pipe(dest, {
     end: false
   })
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(src._readableState.pipes.length, 0)
-  })
+  }, 1)
 }
 {
   const dest = new NullWriteable()
@@ -80,9 +80,9 @@ class NeverEndReadable extends Readable {
   src.pipe(dest, {
     end: false
   })
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(src._readableState.pipes.length, 1)
-  })
+  }, 1)
 }
 {
   const dest = new NullWriteable()
@@ -93,9 +93,9 @@ class NeverEndReadable extends Readable {
     end: false
   })
   src.unpipe(dest)
-  setImmediate(() => {
+  setTimeout(() => {
     assert.strictEqual(src._readableState.pipes.length, 0)
-  })
+  }, 1)
 }
 /* replacement start */
 

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -41,9 +41,9 @@ let nChunks = 10
 const chunk = Buffer.alloc(10, 'x')
 
 r._read = function (n) {
-  setImmediate(() => {
+  setTimeout(() => {
     r.push(--nChunks === 0 ? null : chunk)
-  })
+  }, 1)
 }
 
 let readAll = false

--- a/test/parallel/test-stream-writable-clear-buffer.js
+++ b/test/parallel/test-stream-writable-clear-buffer.js
@@ -25,7 +25,7 @@ class StreamWritable extends Stream.Writable {
   // Otherwise the code will never reach our test case.
 
   _write(chunk, encoding, cb) {
-    setImmediate(cb)
+    setTimeout(cb, 1)
   }
 }
 

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -16,6 +16,8 @@ if (typeof AbortSignal.abort !== 'function') {
 
 ;('use strict')
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -444,9 +446,9 @@ const assert = require('assert')
   let state = 0
   const write = new Writable({
     write(chunk, enc, cb) {
-      // `setImmediate()` is used on purpose to ensure the callback is called
+      // `setTimeout()` is used on purpose to ensure the callback is called
       // after `process.nextTick()` callbacks.
-      setImmediate(cb)
+      setTimeout(cb, 1)
     }
   })
   write.write(

--- a/test/parallel/test-stream-writable-end-cb-error.js
+++ b/test/parallel/test-stream-writable-end-cb-error.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -74,11 +76,11 @@ const stream = require('../../lib/ours/index')
 {
   const w = new stream.Writable({
     write(chunk, encoding, callback) {
-      setImmediate(callback)
+      setTimeout(callback, 1)
     },
 
     finish(callback) {
-      setImmediate(callback)
+      setTimeout(callback, 1)
     }
   })
   w.end(

--- a/test/parallel/test-stream-writable-needdrain-state.js
+++ b/test/parallel/test-stream-writable-needdrain-state.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-writable.js
+++ b/test/parallel/test-stream-writable-writable.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-write-cb-error.js
+++ b/test/parallel/test-stream-writable-write-cb-error.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-write-cb-twice.js
+++ b/test/parallel/test-stream-writable-write-cb-twice.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-writable-write-writev-finish.js
+++ b/test/parallel/test-stream-writable-write-writev-finish.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -35,7 +37,7 @@ const stream = require('../../lib/ours/index') // Ensure consistency between the
   const writable = new stream.Writable()
 
   writable._write = (chunks, encoding, cb) => {
-    setImmediate(cb, new Error('write test error'))
+    setTimeout(cb.bind(null, new Error('write test error')), 1)
   }
 
   writable.on('finish', common.mustNotCall())
@@ -69,19 +71,19 @@ const stream = require('../../lib/ours/index') // Ensure consistency between the
   )
   writable.cork()
   writable.write('test')
-  setImmediate(function () {
+  setTimeout(function () {
     writable.end('test')
-  })
+  }, 1)
 }
 {
   const writable = new stream.Writable()
 
   writable._write = (chunks, encoding, cb) => {
-    setImmediate(cb, new Error('write test error'))
+    setTimeout(cb.bind(null, new Error('write test error')), 1)
   }
 
   writable._writev = (chunks, cb) => {
-    setImmediate(cb, new Error('writev test error'))
+    setTimeout(cb.bind(null, new Error('writev test error')), 1)
   }
 
   writable.on('finish', common.mustNotCall())
@@ -94,9 +96,9 @@ const stream = require('../../lib/ours/index') // Ensure consistency between the
   )
   writable.cork()
   writable.write('test')
-  setImmediate(function () {
+  setTimeout(function () {
     writable.end('test')
-  })
+  }, 1)
 } // Regression test for
 // https://github.com/nodejs/node/issues/13812
 
@@ -112,7 +114,7 @@ const stream = require('../../lib/ours/index') // Ensure consistency between the
   ws.on('error', common.mustCall())
 
   ws._write = (chunk, encoding, done) => {
-    setImmediate(done, new Error())
+    setTimeout(done.bind(null, new Error()), 1)
   }
 
   rs.pipe(ws)

--- a/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
+++ b/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-write-drain.js
+++ b/test/parallel/test-stream-write-drain.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream-write-final.js
+++ b/test/parallel/test-stream-write-final.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -53,11 +53,11 @@ class TestReader extends R {
 }
 
 const reader = new TestReader()
-setImmediate(function () {
+setTimeout(function () {
   assert.strictEqual(ondataCalled, 1)
   silentConsole.log('ok')
   reader.push(null)
-})
+}, 1)
 
 class TestWriter extends W {
   constructor() {

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const tap = require('tap')
 
 const silentConsole = {
@@ -124,9 +126,9 @@ function end() {
   source.emit('end')
   assert(!reading)
   writer.end(stream.read())
-  setImmediate(function () {
+  setTimeout(function () {
     assert(ended)
-  })
+  }, 1)
 }
 /* replacement start */
 

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')
@@ -45,7 +47,7 @@ function test1() {
   //
   // note that this is very unusual.  it only works for crypto streams
   // because the other side of the stream will call read(0) to cycle
-  // data through openssl.  that's why setImmediate() is used to call
+  // data through openssl.  that's why setTimeout() is used to call
   // r.read(0) again later, otherwise there is no more work being done
   // and the process just exits.
 
@@ -55,24 +57,24 @@ function test1() {
   r._read = function (n) {
     switch (reads--) {
       case 5:
-        return setImmediate(() => {
+        return setTimeout(() => {
           return r.push(buf)
-        })
+        }, 1)
 
       case 4:
-        setImmediate(() => {
+        setTimeout(() => {
           return r.push(Buffer.alloc(0))
-        })
-        return setImmediate(r.read.bind(r, 0))
+        }, 1)
+        return setTimeout(r.read.bind(r, 0), 1)
 
       case 3:
-        setImmediate(r.read.bind(r, 0))
+        setTimeout(r.read.bind(r, 0), 1)
         return process.nextTick(() => {
           return r.push(Buffer.alloc(0))
         })
 
       case 2:
-        setImmediate(r.read.bind(r, 0))
+        setTimeout(r.read.bind(r, 0), 1)
         return r.push(Buffer.alloc(0))
       // Not-EOF!
 

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')

--- a/test/parallel/test-stream3-cork-end.js
+++ b/test/parallel/test-stream3-cork-end.js
@@ -46,12 +46,12 @@ function writeChunks(remainingChunks, callback) {
   let writeState
 
   if (writeChunk) {
-    setImmediate(() => {
+    setTimeout(() => {
       writeState = w.write(writeChunk) // We were not told to stop writing.
 
       assert.ok(writeState)
       writeChunks(remainingChunks, callback)
-    })
+    }, 1)
   } else {
     callback()
   }
@@ -84,10 +84,10 @@ writeChunks(inputChunks, () => {
     assert.ok(seen.equals(expected))
   }
 
-  setImmediate(() => {
+  setTimeout(() => {
     // Stream should have ended in next tick.
     assert.ok(seenEnd)
-  })
+  }, 1)
 })
 /* replacement start */
 

--- a/test/parallel/test-stream3-cork-uncork.js
+++ b/test/parallel/test-stream3-cork-uncork.js
@@ -44,12 +44,12 @@ function writeChunks(remainingChunks, callback) {
   let writeState
 
   if (writeChunk) {
-    setImmediate(() => {
+    setTimeout(() => {
       writeState = w.write(writeChunk) // We were not told to stop writing.
 
       assert.ok(writeState)
       writeChunks(remainingChunks, callback)
-    })
+    }, 1)
   } else {
     callback()
   }
@@ -80,10 +80,10 @@ writeChunks(inputChunks, () => {
     assert.ok(seen.equals(expected))
   }
 
-  setImmediate(() => {
+  setTimeout(() => {
     // The stream should not have been ended.
     assert.ok(!seenEnd)
-  })
+  }, 1)
 })
 /* replacement start */
 

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -20,6 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict'
 
+const process = require('process')
+
 const { Buffer } = require('buffer')
 
 const tap = require('tap')
@@ -48,7 +50,7 @@ let chunks = totalChunks
 
 r._read = function (n) {
   silentConsole.log('_read called', chunks)
-  if (!(chunks % 2)) setImmediate(push)
+  if (!(chunks % 2)) setTimeout(push, 1)
   else if (!(chunks % 3)) process.nextTick(push)
   else push()
 }
@@ -107,7 +109,7 @@ function onData() {
         silentConsole.error('seen too much', seen, diff)
       } // Nothing should be lost in-between.
 
-      setImmediate(pipeLittle)
+      setTimeout(pipeLittle, 1)
     }
   })
 } // Just pipe 200 bytes, then unshift the extra and unpipe.
@@ -119,7 +121,7 @@ function pipeLittle() {
   let written = 0
   w.on('finish', () => {
     assert.strictEqual(written, 200)
-    setImmediate(read1234)
+    setTimeout(read1234, 1)
   })
 
   w._write = function (chunk, encoding, cb) {
@@ -136,7 +138,7 @@ function pipeLittle() {
         r.unshift(chunk.slice(chunk.length - diff))
       }
     } else {
-      setImmediate(cb)
+      setTimeout(cb, 1)
     }
   }
 
@@ -160,7 +162,7 @@ function resumePause() {
   r.pause()
   r.resume()
   r.pause()
-  setImmediate(pipe)
+  setTimeout(pipe, 1)
 }
 
 function pipe() {


### PR DESCRIPTION
The `process` object is available within the global scope in Node.js. This object is unavailable in browser environments, but the [process](https://www.npmjs.com/package/process) package can be used as a polyfill. The global `process` object is forwarded in Node.js environments.

This PR
- adds the `process` dependency
- requires the `process` package in every file (lib+test) where `process` is used
- removes the workarounds to load polyfills in the browser tests
- uses `process` instead of `process-es6` in the browser tests